### PR TITLE
Renames ArrayConnection::getOffsetWidthDefault to ArrayConnection::getOffsetWithDefault

### DIFF
--- a/src/Connection/ArrayConnection.php
+++ b/src/Connection/ArrayConnection.php
@@ -38,7 +38,7 @@ class ArrayConnection
      * to use; if the cursor contains a valid offset, that will be used,
      * otherwise it will be the default.
      */
-    public static function getOffsetWidthDefault($cursor, $defaultOffset)
+    public static function getOffsetWithDefault($cursor, $defaultOffset)
     {
         if ($cursor == null){
             return $defaultOffset;
@@ -84,8 +84,8 @@ class ArrayConnection
         $sliceStart = self::getArrayValueSafe($meta, 'sliceStart');
         $arrayLength = self::getArrayValueSafe($meta, 'arrayLength');
         $sliceEnd = $sliceStart + count($arraySlice);
-        $beforeOffset = self::getOffsetWidthDefault($before, $arrayLength);
-        $afterOffset = self::getOffsetWidthDefault($after, -1);
+        $beforeOffset = self::getOffsetWithDefault($before, $arrayLength);
+        $afterOffset = self::getOffsetWithDefault($after, -1);
 
         $startOffset = max([
             $sliceStart - 1,


### PR DESCRIPTION
Fixes a typo

For reference, the JS implementation: https://github.com/graphql/graphql-relay-js/blob/4fdadd3bbf3d5aaf66f1799be3e4eb010c115a4a/src/connection/arrayconnection.js#L184